### PR TITLE
typo "TransparantToggle" -> "TransparentToggle"

### DIFF
--- a/plugin/background.vim
+++ b/plugin/background.vim
@@ -9,5 +9,5 @@ augroup transparent
     command -bar -nargs=0 ClearBackground call background#clear_background()
     command -bar -nargs=0 TransparentDisable call background#disable()
     command -bar -nargs=0 TransparentEnable call background#enable()
-    command -bar -nargs=0 TransparantToggle call background#toggle()
+    command -bar -nargs=0 TransparentToggle call background#toggle()
 augroup END


### PR DESCRIPTION
There is a small typo in one of the command names.
This patch just changes it to be consistent with the others.